### PR TITLE
Migrate to reusable workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  build:
+    name: Build Application
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_build.yml@v1
+    secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,40 +1,16 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   workflow_dispatch:
   push:
-  pull_request:
     branches:
       - main
+      - master
       - develop
-      - master # for safety reasons
-      - dev  # for safety reasons
+  pull_request:
 
 jobs:
   analyse:
-    name: Analyse
-    if: github.event.repository.private == false
-    strategy:
-      matrix:
-        sdk: ["$NANOS_SDK", "$NANOX_SDK", "$NANOSP_SDK", "$STAX_SDK", "$FLEX_SDK"]
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-legacy:latest
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: cpp
-          queries: security-and-quality
-
-      - name: Build
-        run: |
-          make -j BOLOS_SDK=${{ matrix.sdk }}
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+    name: Call Ledger CodeQL analysis
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_codeql_checks.yml@v1
+    secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint Checks
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_lint.yml@v1
+    secrets: inherit

--- a/.github/workflows/ragger-tests.yml
+++ b/.github/workflows/ragger-tests.yml
@@ -1,0 +1,16 @@
+name: Ragger Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  ragger_tests:
+    name: Ragger Tests
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_ragger_tests.yml@v1
+    secrets: inherit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,16 @@
+name: Unit Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  unit_tests:
+    name: Unit Tests
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_unit_tests.yml@v1
+    secrets: inherit


### PR DESCRIPTION
This PR migrates workflows to use centralized reusable workflows from `LedgerHQ/ledger-app-workflows`.

## Changes

- Build and Ragger tests are now combined in `build_and_functional_tests.yml`
- Ragger tests depend on build and use compiled binaries artifact
- Added golden run support for snapshot regeneration
- Other workflows migrated to reusable workflows as needed